### PR TITLE
Add `color` keyword argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,12 @@ redirect streams which get cleaned up at the end of the `iocapture` call.
 
 ### ANSI color/escape code
 
-On Julia v1.6 and later, the captured output of `iocapture` inherits the `:color` property
-of the `stdout` or `stderr` by default. The colorization can be disabled by setting the
-`color` keyword argument of `iocapture` to `false`.
+On Julia v1.6 and later, if the `color` keyword argument is set to `true`, the captured
+output of `iocapture` inherits the `:color` property of the `stdout` or `stderr`.
 
 On the other hand, on Julia v1.5 or earlier, even if the `color` keyword argument is set to
 `true`, no coloring will be applied. However, this limitation might be removed in the
-future, so you should specify `color=false` if you want to avoid coloring.
+future.
 
 
 ## Similar packages

--- a/README.md
+++ b/README.md
@@ -60,12 +60,9 @@ redirect streams which get cleaned up at the end of the `iocapture` call.
 
 ### ANSI color/escape code
 
-On Julia v1.6 and later, if the `color` keyword argument is set to `true`, the captured
-output of `iocapture` inherits the `:color` property of the `stdout` or `stderr`.
-
-On the other hand, on Julia v1.5 or earlier, even if the `color` keyword argument is set to
-`true`, no coloring will be applied. However, this limitation might be removed in the
-future.
+On Julia 1.5 and earlier, setting `color` to `true` has no effect, because the [ability to set `IOContext` attributes on
+redirected streams was added in 1.6](https://github.com/JuliaLang/julia/pull/36688). I.e. on those older Julia versions
+the captured output will generally not contain ANSI color escape sequences.
 
 
 ## Similar packages

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ See the docstring for full documentation.
 
 ## Known limitations
 
+### Separately stored `stdout` or `stderr` objects
+
 The capturing does not work properly if `f` prints to the `stdout` object that has been
 stored in a separate variable or object, e.g.:
 
@@ -55,6 +57,17 @@ Stacktrace:
 
 This is because `stdout` and `stderr` within an `iocapture` actually refer to the temporary
 redirect streams which get cleaned up at the end of the `iocapture` call.
+
+### ANSI color/escape code
+
+On Julia v1.6 and later, the captured output of `iocapture` inherits the `:color` property
+of the `stdout` or `stderr` by default. The colorization can be disabled by setting the
+`color` keyword argument of `iocapture` to `false`.
+
+On the other hand, on Julia v1.5 or earlier, even if the `color` keyword argument is set to
+`true`, no coloring will be applied. However, this limitation might be removed in the
+future, so you should specify `color=false` if you want to avoid coloring.
+
 
 ## Similar packages
 

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -4,7 +4,7 @@ using Logging
 export iocapture
 
 """
-    iocapture(f; throwerrors=true)
+    iocapture(f; throwerrors=true, color=true)
 
 Runs the function `f` and captures the `stdout` and `stderr` outputs without printing them
 in the terminal. Returns an object with the following fields:
@@ -20,6 +20,10 @@ The behaviour can be customized with the following keyword arguments:
   `f`. If set to `false`, exceptions are also captured and the exception objects returned
   via the `.value` field (with also `.error` and `.backtrace` set accordingly). If set to
   `:interrupt`, only `InterruptException`s are rethrown.
+
+* `color`: if set to `true` (default), `iocapture` inherits the `:color` property of
+  `stdout` and `stderr`, which specifies whether ANSI color/escape codes are expected. This
+  argument is only effective on Julia v1.6 and later.
 
 # Extended help
 
@@ -49,7 +53,7 @@ It is also possible to set `throwerrors = :interrupt`, which will make `iocaptur
 only `InterruptException`s. This is useful when you want to capture all the exceptions, but
 allow the user to interrupt the running code with `Ctrl+C`.
 """
-function iocapture(f; throwerrors::Union{Bool,Symbol}=true)
+function iocapture(f; throwerrors::Union{Bool,Symbol}=true, color::Bool=true)
     # Currently, :interrupt is the only valid Symbol value for throwerrors
     if isa(throwerrors, Symbol) && throwerrors !== :interrupt
         throw(DomainError(throwerrors, "Invalid value passed for throwerrors"))
@@ -62,10 +66,17 @@ function iocapture(f; throwerrors::Union{Bool,Symbol}=true)
     # Redirect both the `stdout` and `stderr` streams to a single `Pipe` object.
     pipe = Pipe()
     Base.link_pipe!(pipe; reader_supports_async = true, writer_supports_async = true)
-    redirect_stdout(pipe.in)
-    redirect_stderr(pipe.in)
+    if VERSION >= v"1.6.0-DEV.481" # https://github.com/JuliaLang/julia/pull/36688
+        pe_stdout = IOContext(pipe.in, :color => get(stdout, :color, false) & color)
+        pe_stderr = IOContext(pipe.in, :color => get(stdout, :color, false) & color)
+    else
+        pe_stdout = pipe.in
+        pe_stderr = pipe.in
+    end
+    redirect_stdout(pe_stdout)
+    redirect_stderr(pe_stderr)
     # Also redirect logging stream to the same pipe
-    logger = ConsoleLogger(pipe.in)
+    logger = ConsoleLogger(pe_stderr)
 
     # Bytes written to the `pipe` are captured in `output` and converted to a `String`.
     output = UInt8[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,7 +65,7 @@ end
     @test c.value === nothing
 
     # Colors get discarded
-    c = iocapture(color=false) do
+    c = iocapture() do
         printstyled("foo", color=:red)
     end
     @test !c.error
@@ -73,7 +73,7 @@ end
     @test c.value === nothing
 
     # Colors are preserved if it's supported
-    c = iocapture() do
+    c = iocapture(color=true) do
         printstyled("foo", color=:red)
     end
     @test !c.error
@@ -85,7 +85,7 @@ end
     @test c.value === nothing
 
     # This test checks that deprecation warnings are captured correctly
-    c = iocapture() do
+    c = iocapture(color=true) do
         println("println")
         @info "@info"
         f() = (Base.depwarn("depwarn", :f); nothing)


### PR DESCRIPTION
This is a change intended for Documenter's ANSI color support (cf. https://github.com/JuliaDocs/Documenter.jl/pull/1441)

This adds `color` keyword argument to `iocapture()`. Currently, this argument does not work on Julia v1.5 or earlier, but to avoid version-based conditional branching on the user side, it does not throw an error.

Of course, it is a reasonable option to set `color` to `false` by default. However, I chose `true` for the following reasons.
- It is intuitive that the raw `stdout` output matches the capture result.
- The ANSI escape codes are easy to detect and remove, but impossible to add later.
- Since Julia v1.6 is still in development, this breaking change has little problem.
  - However, we need to bump a minor version as it is not compatible with v0.1.