### PR TITLE
Continuously transfer bytes from pipe to buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IOCapture.jl changelog
 
+## Version `0.2.1`
+
+* ![Bugfix][badge-bugfix] User code that writes a lot into `stdout` or `stderr` no longer stalls in `IOCapture.capture` due to a buffer filling up. ([fredrikekre/Literate.jl#138][literate-138], [#9][github-9])
+
 ## Version `0.2.0`
 
 * ![BREAKING][badge-breaking] ![Enhancement][badge-enhancement] The `iocapture` function has been renamed to `capture` and is no longer exported. The recommended way to refer to the function by fully qualifying the name (i.e. `IOCapture.capture`). ([#3][github-3], [#6][github-6])
@@ -9,7 +13,7 @@
 * ![BREAKING][badge-breaking] ![Enhancement][badge-enhancement] The `throwerrors` keyword argument to `capture` (previously `iocapture`) has been renamed to `rethrow` and accepts now exception types as arguments (instead of `:interrupt`/`true`/`false`). ([#2][github-2], [#4][github-4], [#6][github-6])
 
   **For upgrading:**
-  
+
   * Any uses of `throwerrors = ...` should be replaced by `rethrow = ...`.
   * `throwerrors = :interrupt` (or `rethrow = :interrupt`) should be replaced by `rethrow = InterrupException`.
   * `throwerrors = true` (or `rethrow = true`) should be replaced by `rethrow = Any`.
@@ -29,6 +33,9 @@ Initial release exporting the `iocapture` function.
 [github-3]: https://github.com/JuliaDocs/IOCapture.jl/issues/3
 [github-4]: https://github.com/JuliaDocs/IOCapture.jl/issues/4
 [github-6]: https://github.com/JuliaDocs/IOCapture.jl/pull/6
+[github-9]: https://github.com/JuliaDocs/IOCapture.jl/pull/9
+
+[literate-138]: https://github.com/fredrikekre/Literate.jl/issues/138
 
 
 [badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IOCapture"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 authors = ["Morten Piibeleht", "Michael Hatherly", "IOCapture contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,9 +185,9 @@ end
     @testset "Buffer filling" begin
         for nrows = 2 .^ (0:20)
             c = IOCapture.capture() do
-                for _ in 1:nrows; println("="^80); end
+                for _ in 1:nrows; print("="^80); end
             end
-            @test length(c.output) == 81 * nrows
+            @test length(c.output) == 80 * nrows
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,4 +179,15 @@ end
     @test_throws TypeError IOCapture.capture(()->nothing, rethrow=42)
     @test_throws TypeError IOCapture.capture(()->nothing, rethrow=true)
     @test_throws TypeError IOCapture.capture(()->nothing, rethrow=false)
+
+    # Make sure that IOCapture does not stall if we are printing _a lot_ of bytes into
+    # stdout. X-ref: https://github.com/fredrikekre/Literate.jl/issues/138
+    @testset "Buffer filling" begin
+        for nrows = 2 .^ (0:20)
+            c = IOCapture.capture() do
+                for _ in 1:nrows; println("="^80); end
+            end
+            @test length(c.output) == 81 * nrows
+        end
+    end
 end


### PR DESCRIPTION
This is to avoid filling up the buffer of the Pipe when there is a lot of output going into stdout/-err.

X-ref: based on the implementation suggested by @KristofferC: https://github.com/fredrikekre/Literate.jl/issues/138#issuecomment-796525480