### PR TITLE
Work around a hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IOCapture.jl changelog
 
+## Version `0.2.3`
+
+* ![Bugfix][badge-bugfix] User code that creates a lot of "method definition overwritten" warnings no longer stalls in `IOCapture.capture` due to a buffer not being emptied. ([JuliaDocs/Documenter.jl#2121][documenter-2121], [#15][github-15])
+
 ## Version `0.2.2`
 
 * ![Bugfix][badge-bugfix] `IOCapture.capture` now correctly handles the random number generator seeds on Julia 1.7. ([#11][github-11])
@@ -39,8 +43,11 @@ Initial release exporting the `iocapture` function.
 [github-6]: https://github.com/JuliaDocs/IOCapture.jl/pull/6
 [github-9]: https://github.com/JuliaDocs/IOCapture.jl/pull/9
 [github-11]: https://github.com/JuliaDocs/IOCapture.jl/pull/11
+[github-15]: https://github.com/JuliaDocs/IOCapture.jl/pull/15
 
 [literate-138]: https://github.com/fredrikekre/Literate.jl/issues/138
+
+[documenter-2121]: https://github.com/JuliaDocs/Documenter.jl/issues/2121
 
 
 [badge-breaking]: https://img.shields.io/badge/BREAKING-red.svg

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IOCapture"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 authors = ["Morten Piibeleht", "Michael Hatherly", "IOCapture contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -115,6 +115,7 @@ function capture(f; rethrow::Type=Any, color::Bool=false)
     # Success signals whether the function `f` did or did not throw an exception.
     result, success, backtrace = with_logger(logger) do
         try
+            yield() # avoid hang, see https://github.com/JuliaDocs/Documenter.jl/issues/2121
             f(), true, Vector{Ptr{Cvoid}}()
         catch err
             err isa rethrow && Base.rethrow(err)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,4 +197,19 @@ end
     Random.seed!(1)
     c = IOCapture.capture(() -> rand())
     @test r == c.value
+
+    # Make sure that IOCapture does not stall if we are printing a lot of
+    # "method definition overwritten" warnings.
+    # X-ref: https://github.com/JuliaDocs/Documenter.jl/issues/2121
+    # Note: This test only makes sense when running with `--warn-overwrite=yes`
+    # which is the default since
+    # https://github.com/JuliaLang/Pkg.jl/commit/e576700254b3bd1bbc0a2be2fad257cd70839162
+    @testset "Buffer not being emptied" begin
+        c = IOCapture.capture() do
+            for i in 1:1024
+                eval(:(function TEST_FUNC() 1 end))
+            end
+        end
+        @test true # just make sure we get here
+    end
 end


### PR DESCRIPTION
as suggested by @KristofferC in https://github.com/JuliaDocs/Documenter.jl/issues/2121#issuecomment-1547867929.

 I have verified that this fixes https://github.com/JuliaDocs/Documenter.jl/issues/2121. The `yield` could also be moved to line 109 (or anywhere in between), but I thought right in front of the place where the hang actually occurs (i.e. the call to `f()`) would be most fitting.