### PR TITLE
Allow pass-through of output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IOCapture.jl changelog
 
+## Unreleased
+
+* ![Enhancement][badge-enhancement] `iocapture` now accepts a `passthrough` keyword argument that passes through output to `stdout` as well as capturing it. ([#19][github-19], [#20][github-20])
+
 ## Version `0.2.3`
 
 * ![Bugfix][badge-bugfix] User code that creates a lot of "method definition overwritten" warnings no longer stalls in `IOCapture.capture` due to a buffer not being emptied. ([JuliaDocs/Documenter.jl#2121][documenter-2121], [#15][github-15])
@@ -44,6 +48,8 @@ Initial release exporting the `iocapture` function.
 [github-9]: https://github.com/JuliaDocs/IOCapture.jl/pull/9
 [github-11]: https://github.com/JuliaDocs/IOCapture.jl/pull/11
 [github-15]: https://github.com/JuliaDocs/IOCapture.jl/pull/15
+[github-19]: https://github.com/JuliaDocs/IOCapture.jl/issues/19
+[github-20]: https://github.com/JuliaDocs/IOCapture.jl/pull/20
 
 [literate-138]: https://github.com/fredrikekre/Literate.jl/issues/138
 

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -3,10 +3,10 @@ using Logging
 import Random
 
 """
-    IOCapture.capture(f; rethrow=Any, color=false, pass_through=false)
+    IOCapture.capture(f; rethrow=Any, color=false, passthrough=false)
 
 Runs the function `f` and captures the `stdout` and `stderr` outputs, without printing
-them in the terminal, unless `pass_through=true`.
+them in the terminal, unless `passthrough=true`.
 
 Returns an object with the following fields:
 
@@ -50,7 +50,7 @@ julia> c.output
 
 This approach does have some limitations -- see the README for more information.
 
-If `pass_through=true`, the redirected streams will also be passed through to the
+If `passthrough=true`, the redirected streams will also be passed through to the
 original standard output. As a result, the output from `f` would both be captured and
 shown on screen.
 
@@ -75,7 +75,7 @@ using IOcapture: capture as iocapture
 
 This avoids the function name being too generic.
 """
-function capture(f; rethrow::Type=Any, color::Bool=false, pass_through::Bool=false)
+function capture(f; rethrow::Type=Any, color::Bool=false, passthrough::Bool=false)
     # Original implementation from Documenter.jl (MIT license)
     # Save the default output streams.
     default_stdout = stdout
@@ -111,7 +111,7 @@ function capture(f; rethrow::Type=Any, color::Bool=false, pass_through::Bool=fal
     # pipe to `output` in order to avoid the buffer filling up and stalling write() calls in
     # user code.
     output = IOBuffer()
-    if pass_through
+    if passthrough
         bufsize = 128
         buffer = Vector{UInt8}(undef, bufsize)
         buffer_redirect_task = @async begin

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -52,7 +52,8 @@ This approach does have some limitations -- see the README for more information.
 
 If `passthrough=true`, the redirected streams will also be passed through to the
 original standard output. As a result, the output from `f` would both be captured and
-shown on screen.
+shown on screen. Note that `stdout` and `stderr` are merged in the pass-through, and color
+is stripped unless the `color` option is set to `true`.
 
 **Exceptions.** Normally, if `f` throws an exception, `capture` simply re-throws it with
 `rethrow`. However, by setting `rethrow`, it is also possible to capture errors, which then

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -105,12 +105,14 @@ function capture(f; rethrow::Type=Any, color::Bool=false)
     # pipe to `output` in order to avoid the buffer filling up and stalling write() calls in
     # user code.
     output = IOBuffer()
-    temp = IOBuffer()
+    bufsize = 128
     buffer_redirect_task = @async begin
-        write(temp, pipe)
-        temp_data = take!(temp)
-        write(output, temp_data)
-        write(default_stdout, temp_data)
+        while true
+            buffer = read(pipe, bufsize)
+            write(output, buffer)
+            write(default_stdout, buffer)
+            isempty(buffer) && break
+        end
     end
 
     if old_rng !== nothing

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -3,10 +3,12 @@ using Logging
 import Random
 
 """
-    IOCapture.capture(f; rethrow=Any, color=false)
+    IOCapture.capture(f; rethrow=Any, color=false, pass_through=false)
 
-Runs the function `f` and captures the `stdout` and `stderr` outputs without printing them
-in the terminal. Returns an object with the following fields:
+Runs the function `f` and captures the `stdout` and `stderr` outputs, without printing
+them in the terminal, unless `pass_through=true`.
+
+Returns an object with the following fields:
 
 * `.value :: Any`: return value of the function, or the error exception object on error
 * `.output :: String`: captured `stdout` and `stderr`
@@ -48,6 +50,10 @@ julia> c.output
 
 This approach does have some limitations -- see the README for more information.
 
+If `pass_through=true`, the redirected streams will also be passed through to the
+original standard output. As a result, the output from `f` would both be captured and
+shown on screen.
+
 **Exceptions.** Normally, if `f` throws an exception, `capture` simply re-throws it with
 `rethrow`. However, by setting `rethrow`, it is also possible to capture errors, which then
 get returned via the `.value` field. Additionally, `.error` is set to `true`, to indicate
@@ -69,7 +75,7 @@ using IOcapture: capture as iocapture
 
 This avoids the function name being too generic.
 """
-function capture(f; rethrow::Type=Any, color::Bool=false)
+function capture(f; rethrow::Type=Any, color::Bool=false, pass_through::Bool=false)
     # Original implementation from Documenter.jl (MIT license)
     # Save the default output streams.
     default_stdout = stdout
@@ -105,14 +111,18 @@ function capture(f; rethrow::Type=Any, color::Bool=false)
     # pipe to `output` in order to avoid the buffer filling up and stalling write() calls in
     # user code.
     output = IOBuffer()
-    bufsize = 128
-    buffer_redirect_task = @async begin
-        while true
-            buffer = read(pipe, bufsize)
-            write(output, buffer)
-            write(default_stdout, buffer)
-            isempty(buffer) && break
+    if pass_through
+        bufsize = 128
+        buffer_redirect_task = @async begin
+            while true
+                buffer = read(pipe, bufsize)
+                write(output, buffer)
+                write(default_stdout, buffer)
+                isopen(pipe) || break
+            end
         end
+    else
+        buffer_redirect_task = @async write(output, pipe)
     end
 
     if old_rng !== nothing

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -115,12 +115,11 @@ function capture(f; rethrow::Type=Any, color::Bool=false, pass_through::Bool=fal
         bufsize = 128
         buffer = Vector{UInt8}(undef, bufsize)
         buffer_redirect_task = @async begin
-            while true
+            while !eof(pipe)
                 nbytes = readbytes!(pipe, buffer, bufsize)
                 data = view(buffer, 1:nbytes)
                 write(output, data)
                 write(default_stdout, data)
-                isopen(pipe) || break
             end
         end
     else

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -105,7 +105,13 @@ function capture(f; rethrow::Type=Any, color::Bool=false)
     # pipe to `output` in order to avoid the buffer filling up and stalling write() calls in
     # user code.
     output = IOBuffer()
-    buffer_redirect_task = @async write(output, pipe)
+    temp = IOBuffer()
+    buffer_redirect_task = @async begin
+        write(temp, pipe)
+        temp_data = take!(temp)
+        write(output, temp_data)
+        write(default_stdout, temp_data)
+    end
 
     if old_rng !== nothing
         copy!(Random.default_rng(), old_rng)

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -113,11 +113,13 @@ function capture(f; rethrow::Type=Any, color::Bool=false, pass_through::Bool=fal
     output = IOBuffer()
     if pass_through
         bufsize = 128
+        buffer = Vector{UInt8}(undef, bufsize)
         buffer_redirect_task = @async begin
             while true
-                buffer = read(pipe, bufsize)
-                write(output, buffer)
-                write(default_stdout, buffer)
+                nbytes = readbytes!(pipe, buffer, bufsize)
+                data = view(buffer, 1:nbytes)
+                write(output, data)
+                write(default_stdout, data)
                 isopen(pipe) || break
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,8 +214,7 @@ end
     end
 
     @testset "pass_through" begin
-        logfile = joinpath(@__DIR__, "pass_through.out")
-        open(logfile, "w") do io
+        mktemp() do logfile, io
             redirect_stdout(io) do
                 print("<pre>")
                 c = IOCapture.capture(pass_through=true) do
@@ -225,10 +224,10 @@ end
                 end
                 print("<post>")
             end
+            close(io)
+            @test c.output == "HelloWorld"^128
+            @test read(logfile, String) == "<pre>" * "HelloWorld"^128 * "<post>"
         end
-        @test c.output == "HelloWorld"^128
-        @test read(logfile, String) == "<pre>" * "HelloWorld"^128 * "<post>"
-        rm(logfile)
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,6 +228,26 @@ end
             @test c.output == "HelloWorld"^128
             @test read(logfile, String) == "<pre>" * "HelloWorld"^128 * "<post>"
         end
+        mktemp() do logfile, io
+            redirect_stdout(IOContext(io, :color => true)) do
+                c = IOCapture.capture(passthrough=true) do
+                    printstyled("foo"; color=:red)
+                end
+            end
+            close(io)
+            @test c.output == "foo"
+            @test c.output == read(logfile, String)
+        end
+        mktemp() do logfile, io
+            redirect_stdout(IOContext(io, :color => true)) do
+                c = IOCapture.capture(passthrough=true, color=true) do
+                    printstyled("foo"; color=:red)
+                end
+            end
+            close(io)
+            @test contains(c.output, "\e[")
+            @test c.output == read(logfile, String)
+        end
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -213,11 +213,11 @@ end
         @test true # just make sure we get here
     end
 
-    @testset "pass_through" begin
+    @testset "passthrough" begin
         mktemp() do logfile, io
             redirect_stdout(io) do
                 print("<pre>")
-                c = IOCapture.capture(pass_through=true) do
+                c = IOCapture.capture(passthrough=true) do
                     for i in 1:128
                         print("HelloWorld")
                     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,24 +228,28 @@ end
             @test c.output == "HelloWorld"^128
             @test read(logfile, String) == "<pre>" * "HelloWorld"^128 * "<post>"
         end
+        # Interaction of passthrough= with color=
+        # Also tests that stdout and stderr get merged in both .output and passthrough
         mktemp() do logfile, io
             redirect_stdout(IOContext(io, :color => true)) do
                 c = IOCapture.capture(passthrough=true) do
-                    printstyled("foo"; color=:red)
+                    printstyled(stdout, "foo"; color=:blue)
+                    printstyled(stderr, "bar"; color=:red)
                 end
             end
             close(io)
-            @test c.output == "foo"
+            @test c.output == "foobar"
             @test c.output == read(logfile, String)
         end
         mktemp() do logfile, io
             redirect_stdout(IOContext(io, :color => true)) do
                 c = IOCapture.capture(passthrough=true, color=true) do
-                    printstyled("foo"; color=:red)
+                    printstyled(stdout, "foo"; color=:blue)
+                    printstyled(stderr, "bar"; color=:red)
                 end
             end
             close(io)
-            @test contains(c.output, "\e[")
+            @test c.output == "\e[34mfoo\e[39m\e[31mbar\e[39m"
             @test c.output == read(logfile, String)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,4 +212,23 @@ end
         end
         @test true # just make sure we get here
     end
+
+    @testset "pass_through" begin
+        logfile = joinpath(@__DIR__, "pass_through.out")
+        open(logfile, "w") do io
+            redirect_stdout(io) do
+                print("<pre>")
+                c = IOCapture.capture(pass_through=true) do
+                    for i in 1:128
+                        print("HelloWorld")
+                    end
+                end
+                print("<post>")
+            end
+        end
+        @test c.output == "HelloWorld"^128
+        @test read(logfile, String) == "<pre>" * "HelloWorld"^128 * "<post>"
+        rm(logfile)
+    end
+
 end


### PR DESCRIPTION
Allow to capture `stdout` without disturbing normal output.

Closes #19