### PR TITLE
Add `capture_buffer` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * ![Enhancement][badge-enhancement] `iocapture` now accepts a `passthrough` keyword argument that passes through output to `stdout` as well as capturing it. ([#19][github-19], [#20][github-20])
+* ![Enhancement][badge-enhancement] The new `capture_buffer` keyword argument allows to replace the internal `IOBuffer()` used for capturing, enabling arbitrary dynamic processing of the captured output. ([#21][github-21], [#23][github-23])
 
 ## Version `0.2.3`
 
@@ -50,6 +51,8 @@ Initial release exporting the `iocapture` function.
 [github-15]: https://github.com/JuliaDocs/IOCapture.jl/pull/15
 [github-19]: https://github.com/JuliaDocs/IOCapture.jl/issues/19
 [github-20]: https://github.com/JuliaDocs/IOCapture.jl/pull/20
+[github-21]: https://github.com/JuliaDocs/IOCapture.jl/issues/21
+[github-23]: https://github.com/JuliaDocs/IOCapture.jl/pull/23
 
 [literate-138]: https://github.com/fredrikekre/Literate.jl/issues/138
 

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -75,9 +75,12 @@ all the exceptions, but allow the user to interrupt the running code with `Ctrl+
 **Capture Buffer**
 
 Giving a non-standard `capture_buffer` allows to dynamically process the captured output
-in arbitrary ways. For example, a custom buffer may discard part of some very large
-output. The object passed as `capture_buffer` must implement two methods:
+in arbitrary ways. For example, a custom buffer could truncate the capture of some very
+large output. The object passed as `capture_buffer` must implement two methods:
 `Base.write(capture_buffer, bytes)` and `bytes = Base.take!(capture_buffer)`.
+When combined with `passthrough`, a custom `capture_buffer` will not affect the
+pass-through. Thus, for the example of a truncated capture, the pass-through
+would still show the full output.
 
 **Recommended pattern.** The recommended way to refer to `capture` is by fully qualifying
 the function name with `IOCapture.capture`. This is also why the package does not export

--- a/src/IOCapture.jl
+++ b/src/IOCapture.jl
@@ -3,7 +3,9 @@ using Logging
 import Random
 
 """
-    IOCapture.capture(f; rethrow=Any, color=false, passthrough=false)
+    IOCapture.capture(
+        f; rethrow=Any, color=false, passthrough=false, capture_buffer=IOBuffer()
+    )
 
 Runs the function `f` and captures the `stdout` and `stderr` outputs, without printing
 them in the terminal, unless `passthrough=true`.
@@ -32,12 +34,17 @@ The behaviour can be customized with the following keyword arguments:
   `stderr`, which specifies whether ANSI color/escape codes are expected. This argument is
   only effective on Julia v1.6 and later.
 
+* `passthrough`: if set to `true`, show the output as well as capturing it.
+
+* `capture_buffer`: The internal buffer used to capture the combined `stdout`
+  and `stderr`.
+
 # Extended help
 
 `capture` works by temporarily redirecting the standard output and error streams
 (`stdout` and `stderr`) using `redirect_stdout` and `redirect_stderr` to a temporary
-buffer, evaluate the function `f` and then restores the streams. Both the captured text
-output and the returned object get captured and returned:
+`capture_buffer`, evaluate the function `f` and then restores the streams. Both the
+captured text output and the returned object get captured and returned:
 
 ```jldoctest
 julia> c = IOCapture.capture() do
@@ -65,6 +72,13 @@ As mentioned above, it is also possible to set `rethrow` to `InterruptException`
 make `capture` rethrow only `InterruptException`s. This is useful when you want to capture
 all the exceptions, but allow the user to interrupt the running code with `Ctrl+C`.
 
+**Capture Buffer**
+
+Giving a non-standard `capture_buffer` allows to dynamically process the captured output
+in arbitrary ways. For example, a custom buffer may discard part of some very large
+output. The object passed as `capture_buffer` must implement two methods:
+`Base.write(capture_buffer, bytes)` and `bytes = Base.take!(capture_buffer)`.
+
 **Recommended pattern.** The recommended way to refer to `capture` is by fully qualifying
 the function name with `IOCapture.capture`. This is also why the package does not export
 the function. However, if a shorter name is desired, we recommend renaming the function
@@ -76,7 +90,13 @@ using IOcapture: capture as iocapture
 
 This avoids the function name being too generic.
 """
-function capture(f; rethrow::Type=Any, color::Bool=false, passthrough::Bool=false)
+function capture(
+    f;
+    rethrow::Type=Any,
+    color::Bool=false,
+    passthrough::Bool=false,
+    capture_buffer=IOBuffer()
+)
     # Original implementation from Documenter.jl (MIT license)
     # Save the default output streams.
     default_stdout = stdout
@@ -111,7 +131,6 @@ function capture(f; rethrow::Type=Any, color::Bool=false, passthrough::Bool=fals
     # `String`. We need to use an asynchronous task to continously tranfer bytes from the
     # pipe to `output` in order to avoid the buffer filling up and stalling write() calls in
     # user code.
-    output = IOBuffer()
     if passthrough
         bufsize = 128
         buffer = Vector{UInt8}(undef, bufsize)
@@ -119,12 +138,12 @@ function capture(f; rethrow::Type=Any, color::Bool=false, passthrough::Bool=fals
             while !eof(pipe)
                 nbytes = readbytes!(pipe, buffer, bufsize)
                 data = view(buffer, 1:nbytes)
-                write(output, data)
+                write(capture_buffer, data)
                 write(default_stdout, data)
             end
         end
     else
-        buffer_redirect_task = @async write(output, pipe)
+        buffer_redirect_task = @async write(capture_buffer, pipe)
     end
 
     if old_rng !== nothing
@@ -152,7 +171,7 @@ function capture(f; rethrow::Type=Any, color::Bool=false, passthrough::Bool=fals
     end
     (
         value = result,
-        output = String(take!(output)),
+        output = String(take!(capture_buffer)),
         error = !success,
         backtrace = backtrace,
     )


### PR DESCRIPTION
Giving a non-standard `capture_buffer` allows to dynamically process the captured output in arbitrary ways. For example, a custom buffer may discard part of some very large output. The object passed as `capture_buffer` must implement two methods:
`Base.write(capture_buffer, bytes)` and
`bytes = Base.take!(capture_buffer)`.

Closes #21