### PR TITLE
Add `io_context` keyword argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version [v0.2.5] - 2024-06-12
+
+### Added
+
+* `iocapture` now accepts an `io_context` keyword argument that is passed to the `IOContext` that wraps `stdout` and `stderr`. ([#26])
+
 ## Version [v0.2.4] - 2023-01-17
 
 ### Added
@@ -65,6 +71,7 @@ Initial release exporting the `iocapture` function.
 [v0.2.2]: https://github.com/JuliaDocs/IOCapture.jl/releases/tag/v0.2.2
 [v0.2.3]: https://github.com/JuliaDocs/IOCapture.jl/releases/tag/v0.2.3
 [v0.2.4]: https://github.com/JuliaDocs/IOCapture.jl/releases/tag/v0.2.4
+[v0.2.5]: https://github.com/JuliaDocs/IOCapture.jl/releases/tag/v0.2.5
 [#1]: https://github.com/JuliaDocs/IOCapture.jl/issues/1
 [#2]: https://github.com/JuliaDocs/IOCapture.jl/issues/2
 [#3]: https://github.com/JuliaDocs/IOCapture.jl/issues/3
@@ -76,4 +83,5 @@ Initial release exporting the `iocapture` function.
 [#20]: https://github.com/JuliaDocs/IOCapture.jl/issues/20
 [#21]: https://github.com/JuliaDocs/IOCapture.jl/issues/21
 [#23]: https://github.com/JuliaDocs/IOCapture.jl/issues/23
+[#26]: https://github.com/JuliaDocs/IOCapture.jl/issues/26
 [fredrikekre/Literate.jl#138]: https://github.com/fredrikekre/Literate.jl/issues/138

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IOCapture"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 authors = ["Morten Piibeleht", "Michael Hatherly", "IOCapture contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -294,5 +294,25 @@ end
         end
     end
 
+    if VERSION >= v"1.6.0-DEV.481"
+        @testset "io_context" begin
+            # Avoids needing to define this at top-level as a `module M` syntax.
+            M = Module(:M)
+            Core.eval(M, :(struct T end))
 
+            no_io_context = IOCapture.capture() do
+                println(M.T())
+            end
+            @test rstrip(no_io_context.output) == "Main.M.T()"
+
+            with_io_context = IOCapture.capture(io_context=[:module => M]) do
+                println(M.T())
+            end
+            @test rstrip(with_io_context.output) == "T()"
+
+            @test_throws ArgumentError IOCapture.capture(io_context=["module" => M]) do
+                println(M.T())
+            end
+        end
+    end
 end


### PR DESCRIPTION
Over in https://github.com/PumasAI/QuartoNotebookRunner.jl/issues/143 @jkrumbiegel and I were trying to work out the most straightforward way to get the printing "correct" for types. This seems to be pretty straightforward to me.

I'm open to alternative namings of `io_context`, which seemed to most reasonable to match the rest of the keywords.